### PR TITLE
Use json from the stdlib

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,12 @@ PATH
   remote: .
   specs:
     json-sequence (0.1.0)
-      multi_json (~> 1.13)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
     json (2.1.0)
-    multi_json (1.13.1)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)

--- a/json-sequence.gemspec
+++ b/json-sequence.gemspec
@@ -31,8 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "multi_json", "~> 1.13"
-
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/json_sequence/parser.rb
+++ b/lib/json_sequence/parser.rb
@@ -1,5 +1,5 @@
 require 'json_sequence/result'
-require 'multi_json'
+require 'json'
 
 module JsonSequence
   class Parser
@@ -27,9 +27,9 @@ module JsonSequence
 
         # Try to decode the record
         begin
-          value = MultiJson.load(record)
+          value = JSON.parse(record)
           result = handle_parsed(record, value)
-        rescue MultiJson::ParseError => err
+        rescue JSON::ParserError => err
           result, remaining = handle_err(record, err, is_last_record: i == records.size - 1)
           return remaining if result.nil?
         end


### PR DESCRIPTION
The json library has shipped with the stdlib since ruby 1.9, so multi_json isn't strictly needed.

It does allow us to choose alternative JSON parsers easily, but do we use that option? Maybe we can drop a dependency and keep things simple. Mike Perham has [written about multi-json and reducing dependencies much better than I could](http://www.mikeperham.com/2016/02/09/kill-your-dependencies/).

I'm a 2/10 on this - I just wanted to float the idea to see how others feel.