### PR TITLE
Use 'Dir.glob' instead of 'git ls-files'

### DIFF
--- a/json-sequence.gemspec
+++ b/json-sequence.gemspec
@@ -22,11 +22,10 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    Dir.glob("{bin,lib}/**/*") + %w[README.md Gemfile Gemfile.lock Rakefile LICENSE.txt json-sequence.gemspec]
   end
+
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This is a followup to #3 and I'm hoping will remove our dependency on having git at runtime (when the gem is vendored)

I created the gemfile using:

```
➜ json-sequence git:(remove-git-from-gemspec) gem build json-sequence.gemspec
  Successfully built RubyGem
  Name: json-sequence
  Version: 0.1.1
  File: json-sequence-0.1.1.gem
```

which I then unpacked

```
➜  json-sequence git:(remove-git-from-gemspec) ✗ gem unpack json-sequence-0.1.1.gem
Unpacked gem: '/Users/jeromepaul/Workspace/json-sequence/json-sequence-0.1.1'
➜  json-sequence git:(remove-git-from-gemspec) ✗ cd json-sequence-0.1.1
➜  json-sequence-0.1.1 git:(remove-git-from-gemspec) ✗ find .
.
./bin
./bin/setup
./bin/console
./README.md
./Rakefile
./json-sequence.gemspec
./lib
./lib/json_sequence
./lib/json_sequence/result.rb
./lib/json_sequence/parser.rb
./lib/json_sequence/version.rb
./lib/json_sequence.rb
./Gemfile
./Gemfile.lock
./LICENSE.txt
```
