### PR TITLE
Simplify parser

### DIFF
--- a/lib/json_sequence/version.rb
+++ b/lib/json_sequence/version.rb
@@ -1,3 +1,3 @@
 module JsonSequence
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/json_sequence/parser_spec.rb
+++ b/spec/json_sequence/parser_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe JsonSequence::Parser do
     )
   end
 
+  it 'process records when ending with a RS token' do
+    expect { |b| parser.parse(%|\x1E123\x0A\x1E|, &b) }.to yield_successive_args(
+      JsonSequence::Result::Json.new(123),
+    )
+    expect { |b| parser.parse(%|123\x0A|, &b) }.to yield_successive_args(
+      JsonSequence::Result::Json.new(123),
+    )
+  end
+
   it 'parses formatted json' do
     expect { |b| parser.parse(%|\x1E{"some": "json",\n"more": 1,\n"even more": []}\x0A|, &b) }.to yield_successive_args(
       JsonSequence::Result::Json.new('some' => 'json', 'more' => 1, 'even more' => [])


### PR DESCRIPTION
I found the existing implementation to be too difficult to understand and reason. Hopefully this takes a giant leap into making it more sensible.

This was motivated by me initially seeing a potential problem, that is if the parser skips all empty chunks then it'll never trigger the `is_last_record` and potentially try to read off the edge of the stream. After rewriting it, it makes more sense as it just detects if the stream ended early (complete chunks end with a RS, and `.split(RS, -1)` adds a `''` at the end of the records to ensure it misses that condition. It's structurally backwards, but functions correctly.

Essentially, it performs in two modes:
1. When the record is wrapped on either side by an `RS` it treats it as a complete record
2. When the record doesn't have an `RS` after it, it first checks if its valid json. If its valid json, it returns it, otherwise it stores it in a buffer and waits for the next parse to add it to the buffer and continue

I decided to make those modes more explicit in the logic. As the modes only apply to the last record in the list, we first process all the records normally first and only treat the final one specially.