### PR TITLE
Fix parse error when being sent a single RS octet

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ release a new version, update the version number in `version.rb`, and then run
 `bundle exec rake release`, which will create a git tag for the version, push
 git commits and tags, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
+
+To push the gem to the greensync resource:
+```bash
+gem build greensync-json_sequence.gemspec 
+gem push --key github \                    
+  --host https://rubygems.pkg.github.com/greensync \
+  greensync-json_sequence-x.x.x.gem
+```

--- a/lib/greensync/json_sequence/parser.rb
+++ b/lib/greensync/json_sequence/parser.rb
@@ -21,6 +21,7 @@ module JsonSequence
       # RFC7464 2.1 Multiple consecutive RS octets do not denote empty
       # sequence elements between them and can be ignored.
       records = buffer.split(RS).reject(&:empty?)
+      return '' if records.empty?
 
       # Every record except the last is guaranteed to be completed
       records[0...-1].each { |record| yield decode_record(record) }

--- a/spec/json_sequence/parser_spec.rb
+++ b/spec/json_sequence/parser_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe JsonSequence::Parser do
     )
   end
 
+  it 'ignores keep alive token RS octet' do
+    expect { |b| parser.parse(%|\x1E|, &b) }.not_to yield_control
+  end
+
   it 'supports incremental parsing' do
     expect { |b| parser.parse(%|\x1E{"some": "json"|, &b) }.not_to yield_control
     expect { |b| parser.parse(%|}\x0A|, &b) }.to yield_successive_args(


### PR DESCRIPTION
I suspect this is a way of keeping alive the connection as its completely valid to send repetitive RS octets